### PR TITLE
Support for Joi.forbidden()

### DIFF
--- a/tests.js
+++ b/tests.js
@@ -220,6 +220,25 @@ suite('swagger converts', (s) => {
 		{ type: 'number', format: 'float' }
 	);
 
+
+	simpleTest(
+		joi.object({
+			req: joi.string().required(),
+			forbiddenString: joi.string().forbidden(),
+			forbiddenNumber: joi.number().forbidden(),
+			forbiddenBoolean: joi.boolean().forbidden(),
+			forbiddenBinary: joi.binary().forbidden(),
+			maybeRequiredOrForbidden: joi.number().when('someField', {
+				is: true,
+				then: joi.required(),
+				otherwise: joi.forbidden(),
+			})
+				.meta({ swaggerIndex: 1 }),
+		}),
+		{ type: 'object', required: [ 'req' ], properties: { req: { type: 'string' } } }
+	);
+
+
 	simpleTest(
 		joi.object().keys({
 			id: joi.number().integer().required(),


### PR DESCRIPTION
Implements basic support for `Joi.forbidden()`. 
This is useful for when parameters is required/not required depending on some option: 

```
{
  someField: Joi.string().when('option', {
    is: 'version1',
    then: Joi.required(),
    otherwise: Joi.forbidden()
  })
}
```

