### PR TITLE
#24 Fix type for nullable properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ module.exports = exports = function parse (schema, existingDefinitions) {
 	}
 
 	if (schema._valids && schema._valids.has(null)) {
-		swagger.type = [ swagger.type, 'null' ];
+		swagger.nullable = true;
 	}
 
 	if (schema._description) {

--- a/tests.js
+++ b/tests.js
@@ -135,8 +135,9 @@ suite('swagger converts', (s) => {
 	simpleTest(
 		joi.string().only('A', 'B', 'C', null),
 		{
-			type: [ 'string', 'null' ],
+			type: 'string',
 			enum: [ 'A', 'B', 'C' ],
+			nullable: true,
 		}
 	);
 
@@ -150,7 +151,8 @@ suite('swagger converts', (s) => {
 	simpleTest(
 		joi.boolean().allow(null),
 		{
-			type: [ 'boolean', 'null' ],
+			type: 'boolean',
+			nullable: true,
 		}
 	);
 


### PR DESCRIPTION
This fixes invalid type declaration when `.allow(null)` was used.

Per discussion in #24 