### PR TITLE
#25 Fix invalid definitions references

### DIFF
--- a/index.js
+++ b/index.js
@@ -332,7 +332,7 @@ function meta (schema, key) {
 }
 
 function refDef (name) {
-	return { $ref: '#/definitions/' + name };
+	return { $ref: '#/components/schemas/' + name };
 }
 
 // var inspectU = require('util').inspect;

--- a/tests.js
+++ b/tests.js
@@ -284,7 +284,7 @@ suite('swagger converts', (s) => {
 	simpleTest(
 		joi.string().alphanum().email().meta({ className: 'Email' }),
 		{
-			$ref: '#/definitions/Email',
+			$ref: '#/components/schemas/Email',
 		},
 		{
 			Email: {
@@ -308,8 +308,8 @@ suite('swagger converts', (s) => {
 		{
 			type: 'object',
 			properties: {
-				start: { $ref: '#/definitions/GeoPoint' },
-				stop: { $ref: '#/definitions/GeoPoint' },
+				start: { $ref: '#/components/schemas/GeoPoint' },
+				stop: { $ref: '#/components/schemas/GeoPoint' },
 			},
 		},
 		{


### PR DESCRIPTION
This updates definition references to OpenAPI Spec v3

>  OpenAPI 2.0 had separate sections for reusable components – definitions, parameters, responses and securityDefinitions. In OpenAPI 3.0, they all were moved inside components. Also, definitions were renamed to schemas and securityDefinitions were renamed to securitySchemes (note different spelling: schemAs vs securitySchemEs).
https://swagger.io/docs/specification/components/


As reported in #25 