### PR TITLE
prevent exporting default values as functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ module.exports = exports = function parse (schema, existingComponents) {
 	}
 
 	var defaultValue = get(schema, '_flags.default');
-	if (defaultValue) {
+	if (defaultValue && typeof defaultValue !== 'function') {
 		swagger.default = defaultValue;
 	}
 

--- a/tests.js
+++ b/tests.js
@@ -425,4 +425,12 @@ suite('swagger converts', (s) => {
 			properties: {},
 		}
 	);
+
+	simpleTest(
+		joi.date().default(Date.now, 'current date'),
+		{
+			type: 'string',
+			format: 'date-time',
+	  }
+	);
 });


### PR DESCRIPTION
Joi allows define default value as [function](https://github.com/hapijs/joi/blob/v13.7.0/API.md#anydefaultvalue-description)

Since the library generates swagger definition, it shouldn't export default values as functions