### PR TITLE
Support for any().forbidden()

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,6 +37,10 @@ module.exports = exports = function parse (schema, existingComponents) {
 		return { swagger: refDef(metaDefType, metaDefName) };
 	}
 
+	if (get(schema, '_flags.presence') === 'forbidden') {
+		return false;
+	}
+
 	var swagger;
 	var components = {};
 
@@ -81,10 +85,6 @@ module.exports = exports = function parse (schema, existingComponents) {
 
 	if (override) {
 		Object.assign(swagger, override);
-	}
-
-	if (get(schema, '_flags.presence') === 'forbidden') {
-		return false;
 	}
 
 	return { swagger, components };
@@ -132,11 +132,6 @@ var parseAsType = {
 	},
 	string: (schema) => {
 		var swagger = { type: 'string' };
-
-		if (get(schema, '_flags.presence') === 'forbidden') {
-			return false;
-		}
-
 		var strict = get(schema, '_settings.convert') === false;
 
 		if (find(schema._tests, { name: 'alphanum' })) {
@@ -200,10 +195,6 @@ var parseAsType = {
 	binary: (schema) => {
 		var swagger = { type: 'string', format: 'binary' };
 
-		if (get(schema, '_flags.presence') === 'forbidden') {
-			return false;
-		}
-
 		if (get(schema, '_flags.encoding') === 'base64') {
 			swagger.format = 'byte';
 		}
@@ -227,17 +218,9 @@ var parseAsType = {
 		return swagger;
 	},
 	date: (schema) => {
-
-		if (get(schema, '_flags.presence') === 'forbidden') {
-			return false;
-		}
 		return { type: 'string', format: 'date-time' };
 	},
 	boolean: (schema) => {
-
-		if (get(schema, '_flags.presence') === 'forbidden') {
-			return false;
-		}
 		return { type: 'boolean' };
 	},
 	alternatives: (schema, existingComponents, newComponentsByRef) => {
@@ -273,10 +256,6 @@ var parseAsType = {
 		var itemsSchema = get(schema, [ '_inner', 'items', index ]);
 
 		if (!itemsSchema) throw Error('Array schema does not define an items schema at index ' + index);
-
-		if (get(itemsSchema, '_flags.presence') === 'forbidden') {
-			return false;
-		}
 
 		var items = exports(itemsSchema, merge({}, existingComponents || {}, newComponentsByRef || {}));
 

--- a/index.js
+++ b/index.js
@@ -217,12 +217,8 @@ var parseAsType = {
 
 		return swagger;
 	},
-	date: (schema) => {
-		return { type: 'string', format: 'date-time' };
-	},
-	boolean: (schema) => {
-		return { type: 'boolean' };
-	},
+	date: (/* schema */) => ({ type: 'string', format: 'date-time' }),
+	boolean: (/* schema */) => ({ type: 'boolean' }),
 	alternatives: (schema, existingComponents, newComponentsByRef) => {
 		var index = meta(schema, 'swaggerIndex') || 0;
 

--- a/tests.js
+++ b/tests.js
@@ -432,6 +432,6 @@ suite('swagger converts', (s) => {
 		{
 			type: 'string',
 			format: 'date-time',
-	  }
+		}
 	);
 });

--- a/tests.js
+++ b/tests.js
@@ -234,6 +234,7 @@ suite('swagger converts', (s) => {
 	simpleTest(
 		joi.object({
 			req: joi.string().required(),
+			forbiddenAny: joi.forbidden(),
 			forbiddenString: joi.string().forbidden(),
 			forbiddenNumber: joi.number().forbidden(),
 			forbiddenBoolean: joi.boolean().forbidden(),


### PR DESCRIPTION
Hello,

I have a problem similar to this issue https://github.com/Twipped/joi-to-swagger/issues/12, i. e. the use of joi.forbidden().
At first I thought I would add a special control for "any" in "parseAsType", but finally, I saw that the code already partially handles "forbidden", so I just moved the control a little higher.
It seems to be working, tests are ok.