### PR TITLE
file support

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,30 @@ var patterns = {
 	alphanumUpper: '^[A-Z0-9]*$',
 };
 
+var isJoi = function (joiObj) {
+	return (joiObj && joiObj.isJoi) ? true : false;
+};
+
+var hasJoiMeta = function (joiObj) {
+	return (isJoi(joiObj) && Array.isArray(joiObj._meta)) ? true : false;
+};
+
+var getJoiMetaProperty = function (joiObj, propertyName) {
+
+	// get headers added using meta function
+	if (isJoi(joiObj) && hasJoiMeta(joiObj)) {
+
+		var meta = joiObj._meta;
+		let i = meta.length;
+		while (i--) {
+			if (meta[i][propertyName]) {
+				return meta[i][propertyName];
+			}
+		}
+	}
+	return undefined;
+};
+
 module.exports = exports = function parse (schema, existingComponents) {
 	// inspect(schema);
 
@@ -320,6 +344,18 @@ var parseAsType = {
 
 		return swagger;
 	},
+	any: (schema) => {
+		var swagger = {};
+		// convert property to file upload, if indicated by meta property
+		if (getJoiMetaProperty(schema, 'swaggerType') === 'file') {
+			swagger.type = 'file';
+			swagger.in = 'formData';
+		}
+		if (schema._description) {
+			swagger.description = schema._description;
+		}
+		return swagger;
+	}
 };
 
 function meta (schema, key) {

--- a/tests.js
+++ b/tests.js
@@ -434,4 +434,14 @@ suite('swagger converts', (s) => {
 			format: 'date-time',
 		}
 	);
+
+	// test files
+	simpleTest(
+		joi.any().meta({ swaggerType: 'file' }).description('simpleFile'),
+		{
+			description: 'simpleFile',
+			in: 'formData',
+			type: 'file',
+		}
+	);
 });


### PR DESCRIPTION
file support: `joi.any().meta({ swaggerType: 'file' }).description('json file')` => `{ description: "json file" , in: "formData", required: false, type: "file" }`