### PR TITLE
fix: fixed example parsing for joi version > 14

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,9 +62,9 @@ module.exports = exports = function parse (schema, existingComponents) {
 
 	if (schema._examples.length) {
 		if (schema._examples.length === 1) {
-			swagger.example = schema._examples[0];
+			swagger.example = extractExampleValue(schema._examples[0]);
 		} else {
-			swagger.examples = schema._examples;
+			swagger.examples = schema._examples.map(extractExampleValue);
 		}
 	}
 
@@ -330,6 +330,10 @@ function meta (schema, key) {
 
 function refDef (type, name) {
 	return { $ref: '#/components/' + type + '/' + name };
+}
+
+function extractExampleValue (example) {
+	return joi.version < '14' ? example : example.value;
 }
 
 // var inspectU = require('util').inspect;

--- a/tests.js
+++ b/tests.js
@@ -317,13 +317,17 @@ suite('swagger converts', (s) => {
 
 	simpleTest(
 		joi.string().example('sel').example('wyn'),
-		{
-			examples: [
-				'sel',
-				'wyn',
-			],
-			type: 'string',
-		}
+		joi.version < '14'
+			? {
+				examples: [
+					'sel',
+					'wyn',
+				],
+				type: 'string',
+			} : {
+				example: 'wyn',
+				type: 'string',
+			}
 	);
 
 	simpleTest(


### PR DESCRIPTION
Examples are now objects, as per relase 14.0.0. References:

- https://github.com/hapijs/joi/issues/1615
- https://github.com/glennjones/hapi-swagger/issues/540
- https://github.com/glennjones/hapi-swagger/pull/546