### PR TITLE
Combining schemas:  "oneOf, anyOf, allOf and not" keywords support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
   * BREAKING CHANGE: Move joi to @hapi/joi package with version > 16.0 which was a major rewrite
   * BREAKING CHANGE: Instead of use joi.object().unknown(false) to disallow additional properties
       this is the default now. To allow additional properties use joi.object().unknown()
+  * BREAKING CHANGE: removed support for "swaggerIndex", because it is no longer needed due to added support of "oneOf, anyOf, allOf" keywords
+  * add support for OAS3 "oneOf, anyOf, allOf and not" keywords
+    - this functionality is reflected in the processing of `joi.when()` conditions, `joi.alternatives()` and `joi.array().items()`
+  * add support for "switch" condition - `joi.when('x', { is: true, switch: { ... } })`
+  * add support for "invalid" method - `joi.string().invalid('A','B','C')`
+  * add add support for "uuid" format for string type
+  * add support for ES6 default import syntax
 
 3.3.0 / 2019-10-18
 ==================

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const joi = require('@hapi/joi');
-const { find, get, set, merge } = require('lodash');
+const { find, get, isEqual, isNumber, isPlainObject, isString, merge, set, uniqWith } = require('lodash');
 
 const patterns = {
 	alphanum: '^[a-zA-Z0-9]*$',
@@ -49,6 +49,43 @@ function getCaseSuffix (schema) {
 	return '';
 }
 
+function parseWhens (schema, existingComponents, newComponentsByRef) {
+	const whens = get(schema, '$_terms.whens');
+	const mode = whens.length > 1 ? 'anyOf' : 'oneOf';
+
+	const alternatives = [];
+	for (const w of whens) {
+		if (w.then) alternatives.push(w.then);
+		if (w.otherwise) alternatives.push(w.otherwise);
+		if (w.switch) {
+			for (const s of w.switch) {
+				if (s.then) alternatives.push(s.then);
+				if (s.otherwise) alternatives.push(s.otherwise);
+			}
+		}
+	}
+
+	let swaggers = [];
+	for (const joiSchema of alternatives) {
+		// eslint-disable-next-line max-len
+		const { swagger, components } = parse(joiSchema, merge({}, existingComponents || {}, newComponentsByRef || {}));
+		if (!swagger) continue; // swagger is falsy if joi.forbidden()
+		// if (get(joiSchema, '_flags.presence') === 'required') {
+		// 	swagger['x-required'] = true;
+		// }
+		merge(newComponentsByRef, components || {});
+		swaggers.push(swagger);
+	}
+	swaggers = uniqWith(swaggers, isEqual);
+
+	let openapi = { [mode]: swaggers };
+	if (swaggers.length <= 1) {
+		openapi = get(swaggers, [ 0 ]) || {};
+	}
+
+	return openapi;
+}
+
 const parseAsType = {
 	number: (schema) => {
 		const swagger = {};
@@ -84,9 +121,16 @@ const parseAsType = {
 		}
 
 		if (schema._valids) {
-			const valids = schema._valids.values().filter((s) => typeof s === 'number');
+			const valids = schema._valids.values().filter((s) => isNumber(s));
 			if (get(schema, '_flags.only') && valids.length) {
 				swagger.enum = valids;
+			}
+		}
+
+		if (schema._invalids) {
+			const invalids = schema._invalids.values().filter((s) => isNumber(s));
+			if (invalids.length) {
+				swagger.not = { enum: invalids };
 			}
 		}
 
@@ -127,9 +171,16 @@ const parseAsType = {
 		Object.assign(swagger, getMinMax(schema));
 
 		if (schema._valids) {
-			const valids = schema._valids.values().filter((s) => typeof s === 'string');
+			const valids = schema._valids.values().filter((s) => isString(s));
 			if (get(schema, '_flags.only') && valids.length) {
 				swagger.enum = valids;
+			}
+		}
+
+		if (schema._invalids) {
+			const invalids = schema._invalids.values().filter((s) => isString(s));
+			if (invalids.length) {
+				swagger.not = { enum: invalids };
 			}
 		}
 
@@ -149,53 +200,79 @@ const parseAsType = {
 	date: (/* schema */) => ({ type: 'string', format: 'date-time' }),
 	boolean: (/* schema */) => ({ type: 'boolean' }),
 	alternatives: (schema, existingComponents, newComponentsByRef) => {
-		const index = meta(schema, 'swaggerIndex') || 0;
+		const matches = get(schema, '$_terms.matches');
+		const mode = `${get(schema, '_flags.match') || 'any'}Of`;
 
-		const matches = get(schema, [ '$_terms', 'matches' ]);
-		const firstItem = get(matches, [ 0 ]);
-
-		let itemsSchema;
-		if (firstItem.ref) {
-			if (schema._baseType && !firstItem.otherwise) {
-				itemsSchema = index ? firstItem.then : schema._baseType;
+		const alternatives = [];
+		for (const m of matches) {
+			if (m.ref) {
+				if (m.then) alternatives.push(m.then);
+				if (m.otherwise) alternatives.push(m.otherwise);
+				if (m.switch) {
+					for (const s of m.switch) {
+						if (s.then) alternatives.push(s.then);
+						if (s.otherwise) alternatives.push(s.otherwise);
+					}
+				}
 			} else {
-				itemsSchema = index ? firstItem.otherwise : firstItem.then;
+				alternatives.push(m.schema);
 			}
-		} else if (index) {
-			itemsSchema = get(matches, [ index, 'schema' ]);
-		} else {
-			itemsSchema = firstItem.schema;
 		}
 
-		const items = parse(itemsSchema, merge({}, existingComponents || {}, newComponentsByRef || {}));
-		if (get(itemsSchema, '_flags.presence') === 'required') {
-			items.swagger.__required = true;
+		let swaggers = [];
+		for (const joiSchema of alternatives) {
+			// eslint-disable-next-line max-len
+			const { swagger, components } = parse(joiSchema, merge({}, existingComponents || {}, newComponentsByRef || {}));
+			if (!swagger) continue; // swagger is falsy if joi.forbidden()
+			// if (get(joiSchema, '_flags.presence') === 'required') {
+			// 	swagger['x-required'] = true;
+			// }
+			merge(newComponentsByRef, components || {});
+
+			swaggers.push(swagger);
+		}
+		swaggers = uniqWith(swaggers, isEqual);
+
+		let openapi = { [mode]: swaggers };
+		if (swaggers.length <= 1) {
+			openapi = get(swaggers, [ 0 ]) || {};
 		}
 
-		merge(newComponentsByRef, items.components || {});
-
-		return items.swagger;
+		return openapi;
 	},
 	array: (schema, existingComponents, newComponentsByRef) => {
-		const index = meta(schema, 'swaggerIndex') || 0;
-		const itemsSchema = get(schema, [ '$_terms', 'items', index ]);
+		const items = get(schema, '$_terms.items');
+		const mode = 'oneOf';
 
-		if (!itemsSchema) throw Error('Array schema does not define an items schema at index ' + index);
+		const alternatives = items;
 
-		const items = parse(itemsSchema, merge({}, existingComponents || {}, newComponentsByRef || {}));
+		let swaggers = [];
+		for (const joiSchema of alternatives) {
+			// eslint-disable-next-line max-len
+			const { swagger, components } = parse(joiSchema, merge({}, existingComponents || {}, newComponentsByRef || {}));
+			if (!swagger) continue; // swagger is falsy if joi.forbidden()
 
-		merge(newComponentsByRef, items.components || {});
+			merge(newComponentsByRef, components || {});
 
-		const swagger = { type: 'array' };
+			swaggers.push(swagger);
+		}
+		swaggers = uniqWith(swaggers, isEqual);
 
-		Object.assign(swagger, getMinMax(schema, 'Items'));
-
-		if (find(schema._rules, { name: 'unique' })) {
-			swagger.uniqueItems = true;
+		const openapi = {
+			type: 'array',
+			items: { [mode]: swaggers },
+		};
+		if (swaggers.length <= 1) {
+			openapi.items = get(swaggers, [ 0 ]) || {};
 		}
 
-		swagger.items = items.swagger;
-		return swagger;
+		Object.assign(openapi, getMinMax(schema, 'Items'));
+
+		if (find(schema._rules, { name: 'unique' })) {
+			openapi.uniqueItems = true;
+		}
+
+		return openapi;
 	},
 	object: (schema, existingComponents, newComponentsByRef) => {
 
@@ -207,19 +284,18 @@ const parseAsType = {
 		const children = get(schema, '$_terms.keys') || [];
 		children.forEach((child) => {
 			const key = child.key;
-			const prop = parse(child.schema, combinedComponents);
-			if (!prop.swagger) { // swagger is falsy if joi.forbidden()
+			const { swagger, components } = parse(child.schema, combinedComponents);
+			if (!swagger) { // swagger is falsy if joi.forbidden()
 				return;
 			}
 
-			merge(newComponentsByRef, prop.components || {});
-			merge(combinedComponents, prop.components || {});
+			merge(newComponentsByRef, components || {});
+			merge(combinedComponents, components || {});
 
-			properties[key] = prop.swagger;
+			properties[key] = swagger;
 
-			if (get(child, 'schema._flags.presence') === 'required' || prop.swagger.__required) {
+			if (get(child, 'schema._flags.presence') === 'required') {
 				requireds.push(key);
-				delete prop.swagger.__required;
 			}
 		});
 
@@ -242,6 +318,21 @@ const parseAsType = {
 			swagger.type = 'file';
 			swagger.in = 'formData';
 		}
+
+		if (schema._valids) {
+			const valids = schema._valids.values().filter((s) => isString(s) || isNumber(s));
+			if (get(schema, '_flags.only') && valids.length) {
+				swagger.enum = valids;
+			}
+		}
+
+		if (schema._invalids) {
+			const invalids = schema._invalids.values().filter((s) => isString(s) || isNumber(s));
+			if (invalids.length) {
+				swagger.not = { enum: invalids };
+			}
+		}
+
 		return swagger;
 	},
 };
@@ -251,11 +342,11 @@ function parse (schema, existingComponents) {
 
 	if (!schema) throw new Error('No schema was passed.');
 
-	if (typeof schema === 'object' && !joi.isSchema(schema)) {
+	if (isPlainObject(schema)) {
 		schema = joi.object().keys(schema);
 	}
 
-	if (!schema.type || !schema.$_root) throw new TypeError('Passed schema does not appear to be a joi schema.');
+	if (!joi.isSchema(schema)) throw new TypeError('Passed schema does not appear to be a joi schema.');
 
 	const flattenMeta = Object.assign.apply(null, [ {} ].concat(schema.$_terms.metas));
 
@@ -285,7 +376,10 @@ function parse (schema, existingComponents) {
 	}
 
 	const components = {};
-	const swagger = parseAsType[type](schema, existingComponents, components);
+	const swagger =  parseAsType[type](schema, existingComponents, components);
+	if (get(schema, '$_terms.whens')) {
+		Object.assign(swagger, parseWhens(schema, existingComponents, components));
+	}
 
 	if (!swagger) return { swagger, components };
 
@@ -333,5 +427,5 @@ exports.default = parse;
 
 // const inspectU = require('util').inspect;
 // function inspect (value) {
-// 		console.error(inspectU(value, { colors: true, depth: 10 }));
+// 	console.error(inspectU(value, { colors: true, depth: 10 }));
 // }

--- a/tests.js
+++ b/tests.js
@@ -344,8 +344,8 @@ suite('swagger converts', (s) => {
 			a: joi.any()
 				.when('b', {
 					is: joi.exist(),
-					then: joi.string().valid('A'),
-					otherwise: joi.string().valid('B'),
+					then: joi.string().valid('A').required(),
+					otherwise: joi.string().valid('B').required(),
 				})
 				.when('c', { is: joi.number().min(10), then: joi.string().valid('C') }),
 			b: joi.any(),
@@ -359,10 +359,12 @@ suite('swagger converts', (s) => {
 						{
 							type: 'string',
 							enum: [ 'A' ],
+							'x-required': true,
 						},
 						{
 							type: 'string',
 							enum: [ 'B' ],
+							'x-required': true,
 						},
 						{
 							type: 'string',
@@ -423,9 +425,9 @@ suite('swagger converts', (s) => {
 			forbiddenNumber: joi.number().forbidden(),
 			forbiddenBoolean: joi.boolean().forbidden(),
 			forbiddenBinary: joi.binary().forbidden(),
-			maybeForbidden: joi.when('someField', {
+			maybeRequiredOrForbidden: joi.number().when('someField', {
 				is: true,
-				then: joi.number().integer().min(1).max(10),
+				then: joi.required(),
 				otherwise: joi.forbidden(),
 			}),
 		}),
@@ -434,10 +436,12 @@ suite('swagger converts', (s) => {
 			required: [ 'req' ],
 			properties: {
 				req: { type: 'string' },
-				maybeForbidden: {
-					type: 'integer',
-					minimum: 1,
-					maximum: 10,
+				maybeRequiredOrForbidden: {
+					type: 'number',
+					format: 'float',
+					oneOf: [
+						{ 'x-required': true },
+					],
 				},
 			},
 			additionalProperties: false,
@@ -602,12 +606,18 @@ suite('swagger converts', (s) => {
 	simpleTest(
 		{
 			id: joi.string()
-				.when('version', { is: joi.number().greater(0).required(), then: joi.string().required() }),
+				.when('version', { is: joi.number().greater(0).required(), then: joi.required() }),
 		},
 		{
 			type: 'object',
 			properties: {
-				id: { type: 'string' },
+				id: {
+					type: 'string',
+					oneOf: [
+						{ 'x-required': true },
+					],
+
+				},
 			},
 			additionalProperties: false,
 		}


### PR DESCRIPTION
Hello,
in our project we need support for the OpenAPI 3 specification and we also would like to continue to use your library without creating our own "fork".
Therefore I have prepared this "pull request" with support of "oneOf, anyOf, allOf and not" keywords. Details can be found here: https://swagger.io/docs/specification/data-models/oneof-anyof-allof-not/

### Added:
- support for OAS3 "oneOf, anyOf, allOf and not" keywords
  - this functionality is reflected in the processing of "joi.when()" conditions, "joi.alternatives()" and "joi.array()"
- support for "switch" condition ( joi.when('x', { is: true, switch: { ... } }) )
- support for invalid method ( joi.string().invalid('A','B','C') )

### Fixed:
- compatibility with @hapi/joi v16

### Breaking changes:
- removed support for "swaggerIndex", because it is no longer needed due to added support of "oneOf, anyOf, allOf" keywords

### Could be discussed:
- in case of "joi.when()" and "joi.alternatives()" the "joi.required()" is just implemented as a custom property option called "x-required", e.g. `x-required: true`. The final swagger definition will be valid and information about the possible mandatory properties will be retained
- or "required" properties could be added to "anyOf" array at "object" level, but it will not be clear to which specific subschema it belongs to. e.g.:
```
{
  "type": "object",
  "properties": {
    "user_id": {
      "oneOf": [
        { "type" : "number" },
        { "type" : "string" }
      ]
    },
    "type": {
      "type" : "string",
      "oneOf": [
        { "enum" : ["A", "B"] },
        { "enum" : ["C", "D"] }
      ]
    },
    "name": {
      "type": "string"
    }
  },
  "anyOf": [
    { "required": [ "user_id" ] },
    { "required": ["type"] }
  ]
}
```
- it could be also implemented like this:
```
{
  "type": "object",
  "properties": {
    "user_id": {},
    "type": {},
    "name": {
      "type": "string"
    }
  },
  "allOf": [
    {
      "oneOf": [
        {
          "required": ["user_id"],
          "properties": {
            "user_id": {
              "type": "number"
            }
          }
        },
        {
          "required": ["user_id"],
          "properties": {
            "user_id": {
              "type": "string"
            }
          }
        }
      ]
    },
    {
      "oneOf": [
        {
          "required": ["type"],
          "properties": {
            "type": {
              "type": "string",
              "enum": ["A", "B"]
            }
          }
        },
        {
          "required": ["type"],
          "properties": {
            "type": {
              "type": "string",
              "enum": ["C", "D"]
            }
          }
        }
      ]
    } 
  ]
}
```
but it creates a lot of boilerplate code and from my point of view this kind of definition is not clearly displayed in Swagger UI