### PR TITLE
feat: add schemaOverride meta option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+5.2.0 / 2020-12-29
+==================
+
+  * Add option to override the Joi schema which generates swagger.
+
 5.0.1 / 2020-08-13
 ==================
 

--- a/README.md
+++ b/README.md
@@ -151,6 +151,25 @@ The following may be provided on a joi `.meta()` object to explicitly override d
 
 **swaggerType**: Can be used with the .any() type to add files.
 
+**schemaOverride**: A replacement Joi schema which is used to generate swagger. For example, AWS API Gateway supports a subset of the swagger spec. In order to utilize
+this library with AWS API Gateway's swagger, this option is useful when working with Joi.alternatives().
+
+The example below uses `joi.when`, which would normally use `oneOf`, `anyOf`, or `allOf` keywords. In order to get around that, the meta tag overrides the schema to be similar, but less strict.
+```
+joi.object({
+  type: joi.string().valid('a', 'b'),
+  body: when('type', {
+    is: 'a',
+    then: joi.object({ a: joi.string() }),
+    otherwise: when('type', {
+      is: 'b',
+      then: joi.object({ b: joi.string() }),
+      otherwise: joi.forbidden()
+    })
+  })
+}).meta({ schemaOverride: joi.object({ a: joi.string(), b: joi.string() })})
+```
+
 ## Custom Types (joi.extend)
 
 For supporting custom joi types you can add the needed type information using a the meta property **baseType**.

--- a/index.js
+++ b/index.js
@@ -303,7 +303,7 @@ const parseAsType = {
 	},
 };
 
-function parse (schema, existingComponents) {
+function parse (schema, existingComponents, isSchemaOverride) {
 	// inspect(schema);
 
 	if (!schema) throw new Error('No schema was passed.');
@@ -315,6 +315,12 @@ function parse (schema, existingComponents) {
 	if (!joi.isSchema(schema)) throw new TypeError('Passed schema does not appear to be a joi schema.');
 
 	const flattenMeta = Object.assign.apply(null, [ {} ].concat(schema.$_terms.metas));
+
+	const schemaOverride = flattenMeta.schemaOverride;
+	if (schemaOverride) {
+		if (isSchemaOverride) throw new Error('Cannot override the schema for one which is being used in another override (no nested schema overrides).');
+		return parse(schemaOverride, existingComponents, true);
+	}
 
 	const override = flattenMeta.swagger;
 	if (override && flattenMeta.swaggerOverride) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "joi-to-swagger",
-  "version": "5.0.1",
+  "version": "5.2.0",
   "description": "",
   "main": "index.js",
   "types": "index.d.ts",

--- a/tests.js
+++ b/tests.js
@@ -840,6 +840,22 @@ suite('swagger converts', (s) => {
 		},
 	);
 
+	// custom swagger schemas with schemaOverride
+	simpleTest(
+		'using meta schemaOverride',
+		joi.alternatives().meta({ schemaOverride: joi.number() }),
+		{
+			type: 'number',
+			format: 'float',
+		},
+	);
+
+	testError(
+		'nested schemaOverride fails',
+		joi.object({}).meta({ schemaOverride: joi.object({}).meta({ schemaOverride: joi.object({}) }) }),
+		new Error('Cannot override the schema for one which is being used in another override (no nested schema overrides).'),
+	);
+
 	// custom swagger schemas with swagger and swaggerOverride
 	simpleTest(
 		'using meta swagger',


### PR DESCRIPTION
This meta option will allow users to specify a Joi schema to use for the
swagger generation, instead of the schema to which the option is set. The feature
is useful in cases where you use the same Joi schema for validation and swagger
generation, but the swagger output is incompatible with your application.

For example, AWS API Gateway supports a subset of the swagger spec. In order to utilize
this library with AWS API Gateway's swagger, this option is useful when working with
Joi.alternatives().