### PR TITLE
Fix: enable support for Key-Value Maps via additionalProperties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
+6.1.0 / 2022-07-09
+==================
+  * add support for object.pattern() (thanks @JKEnv)
+
 6.0.0 + 6.0.1 / 2021-07-30
-=================
+==========================
 
   BREAKING CHANGE: override will now also be applied if className is used
   BREAKING CHANGE: swaggerOverride will not ignore className anymore

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ J2S returns a result object containing `swagger` and `components` properties. `s
 - `joi.object()`
   - `.unknown(false)` -> `additionalProperties: false`
   - `.required()` on object members produces a `"required": []` array
+  - `.pattern(pattern, JoiSchema)` -> `additionalProperties: [Schema]`
 
 - `joi.array().items()` - in case of multiple provided schemas using `items()` method, the "oneOf" (OAS3) keyword is used
   - `.min(4)` -> `"minItems": 4`

--- a/index.js
+++ b/index.js
@@ -259,6 +259,7 @@ const parseAsType = {
 
 		const requireds = [];
 		const properties = {};
+		let additionalProperties = {};
 
 		const combinedComponents = merge({}, existingComponents || {}, newComponentsByRef || {});
 
@@ -281,6 +282,23 @@ const parseAsType = {
 
 		});
 
+		if(!children.length) {
+			let patterns = get(schema, '$_terms.patterns');
+			if(patterns) {
+				patterns.forEach(pattern => {
+					if(pattern?.rule) {
+						const { swagger, components } = parse(pattern.rule, combinedComponents);
+						if (!swagger) { // swagger is falsy if joi.forbidden()
+							return;
+						}
+						additionalProperties = swagger;
+					}
+				})
+				
+
+			}
+		}
+
 		const swagger = {
 			type: 'object',
 			properties,
@@ -291,6 +309,10 @@ const parseAsType = {
 
 		if (get(schema, '_flags.unknown') !== true) {
 			swagger.additionalProperties = false;
+		}
+
+		if(Object.keys(additionalProperties).length !== 0){
+			swagger.additionalProperties = additionalProperties;
 		}
 
 		return swagger;

--- a/index.js
+++ b/index.js
@@ -282,20 +282,18 @@ const parseAsType = {
 
 		});
 
-		if(!children.length) {
-			let patterns = get(schema, '$_terms.patterns');
-			if(patterns) {
-				patterns.forEach(pattern => {
-					if(pattern?.rule) {
-						const { swagger, components } = parse(pattern.rule, combinedComponents);
+		if (!children.length) {
+			const keyPatterns = get(schema, '$_terms.patterns');
+			if (keyPatterns) {
+				keyPatterns.forEach((pattern) => {
+					if (pattern.rule) {
+						const { swagger } = parse(pattern.rule, combinedComponents);
 						if (!swagger) { // swagger is falsy if joi.forbidden()
 							return;
 						}
 						additionalProperties = swagger;
 					}
-				})
-				
-
+				});
 			}
 		}
 
@@ -311,7 +309,7 @@ const parseAsType = {
 			swagger.additionalProperties = false;
 		}
 
-		if(Object.keys(additionalProperties).length !== 0){
+		if (Object.keys(additionalProperties).length !== 0) {
 			swagger.additionalProperties = additionalProperties;
 		}
 

--- a/tests.js
+++ b/tests.js
@@ -339,6 +339,97 @@ suite('swagger converts', (s) => {
 	);
 
 	simpleTest(
+		'object with pattern for keys and string as value',
+		joi.object().pattern(/^/, joi.string()),
+		{
+			type: 'object',
+			properties: {},
+			additionalProperties: {
+				type: 'string',
+			},
+		},
+	);
+
+	simpleTest(
+		'object with pattern for keys and object as value',
+		joi.object().pattern(/^/, joi.object({ name: joi.string(), date: joi.date() })),
+		{
+			type: 'object',
+			properties: {
+			},
+			additionalProperties: {
+				type: 'object',
+				properties: {
+					name: {
+						type: 'string',
+					},
+					date: {
+						type: 'string',
+						format: 'date-time',
+					},
+				},
+				additionalProperties: false,
+			},
+		},
+	);
+
+	simpleTest(
+		'object with pattern for keys and array as value',
+		joi.object().pattern(/^/, joi.array().items(joi.object({ name: joi.string(), date: joi.date() }))),
+		{
+			type: 'object',
+			properties: {
+			},
+			additionalProperties: {
+				type: 'array',
+				items: {
+					type: 'object',
+					properties: {
+						name: {
+							type: 'string',
+						},
+						date: {
+							type: 'string',
+							format: 'date-time',
+						},
+					},
+					additionalProperties: false,
+				},
+			},
+		},
+	);
+
+	simpleTest(
+		'object with pattern for keys and alternative as value',
+		joi.object().pattern(/^/, joi.alternatives(joi.object({ name: joi.string(), date: joi.date() }), joi.string())),
+		{
+			type: 'object',
+			properties: {
+			},
+			additionalProperties: {
+				anyOf: [
+					{
+						type: 'object',
+						properties: {
+							name: {
+								type: 'string',
+							},
+							date: {
+								type: 'string',
+								format: 'date-time',
+							},
+						},
+						additionalProperties: false,
+					},
+					{
+						type: 'string',
+					},
+				],
+			},
+		},
+	);
+
+	simpleTest(
 		'alternatives of string or number',
 		joi.alternatives(joi.string(), joi.number()),
 		{

--- a/tests.js
+++ b/tests.js
@@ -351,6 +351,16 @@ suite('swagger converts', (s) => {
 	);
 
 	simpleTest(
+		'object with pattern for keys and forbidden value',
+		joi.object().pattern(/^/, joi.string().forbidden()),
+		{
+			type: 'object',
+			properties: {},
+			additionalProperties: false,
+		},
+	);
+
+	simpleTest(
 		'object with pattern for keys and object as value',
 		joi.object().pattern(/^/, joi.object({ name: joi.string(), date: joi.date() })),
 		{


### PR DESCRIPTION
This fix enables the following swagger function:
https://swagger.io/docs/specification/data-models/dictionaries/

This is how its done via Joi:
Joi.object().pattern(/^/, Joi.object({name: Joi.string()}))


I've tested this in a personal project.